### PR TITLE
Fixes #7545: Disable proxy for wget and curl commands.

### DIFF
--- a/bin/service-wait
+++ b/bin/service-wait
@@ -43,11 +43,11 @@ ignore-retval () {
 wait-for-url () {
     # we use wget first because it's able to retry from connrefused situation
     /usr/bin/wget --timeout=1 -4 --tries=$WAIT_MAX --retry-connrefused -qO-\
-                  --no-check-certificate $1 > /dev/null
+                  --no-check-certificate --no-proxy $1 > /dev/null
     # then we double check with curl that the service is really
     # available. wget is not able to retry from 'Unable to establish
     # SSL connection.' error, which happens for example with tomcat6
-    /usr/bin/curl -ks --retry $WAIT_MAX --retry-delay 1 $1 > /dev/null
+    /usr/bin/curl -ks --retry $WAIT_MAX --retry-delay 1 --noproxy '*' $1 > /dev/null
 
     if ! [ $? = '0' ]; then
         RETVAL=5


### PR DESCRIPTION
If a user specifies system wide proxy settings via http_proxy and https_proxy
environment variables, the checks of wget and curl for services can fail. For
example, Candlepin checks localhost for tomcat initialization which can't be
reached when going through a proxy.