### PR TITLE
Fixes #9243: Ensure service_wait is called on systems with systemd.

### DIFF
--- a/bin/service-wait
+++ b/bin/service-wait
@@ -11,8 +11,16 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-SERVICE=$1
-COMMAND=$2
+VERSION_ID=`cat /etc/os-release | grep VERSION_ID`
+
+if [[ $VERSION_ID == *'7'* ]]
+then
+    COMMAND=$1
+    SERVICE=$2
+else
+    COMMAND=$2
+    SERVICE=$1
+fi
 
 PLUGINS_DIR=${PLUGINS_DIR:-"$(dirname $(readlink -f $BASH_SOURCE))/../plugins"}
 # number of attemts to check the service

--- a/lib/puppet/provider/service/service_wait.rb
+++ b/lib/puppet/provider/service/service_wait.rb
@@ -2,12 +2,9 @@
 Puppet::Type.type(:service).provide :service_wait, :parent => :systemd do
   desc "Manages services using `service-wait` command."
 
-  commands :service => File.expand_path("../../../../../bin/service-wait", __FILE__)
+  commands :systemctl => File.expand_path("../../../../../bin/service-wait", __FILE__)
 
-  defaultfor :osfamily => [:redhat], :operatingsystemmajrelease => "7"
-  #everything but el6
-  confine :false => (Puppet[:operatingsystemrelease] =~ /^6.*/)
-  confine :osfamily => /^(RedHat|Linux)/
+  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => "7"
 
   def self.specificity
    # The specificity determines which provider wins at the end


### PR DESCRIPTION
For systems that use systemd, such as EL7, the command is no longer
service but systemctl. This specific command needs to be set as the
provider command so that service_wait is invoked for systemd.