### PR TITLE
Use systemd tooling

### DIFF
--- a/bin/service-wait
+++ b/bin/service-wait
@@ -11,16 +11,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-VERSION_ID=`cat /etc/os-release | grep VERSION_ID`
-
-if [[ $VERSION_ID == *'7'* ]]
-then
-    COMMAND=$1
-    SERVICE=$2
-else
-    COMMAND=$2
-    SERVICE=$1
-fi
+COMMAND=$1
+SERVICE=$2
 
 PLUGINS_DIR=${PLUGINS_DIR:-"$(dirname $(readlink -f $BASH_SOURCE))/../plugins"}
 # number of attemts to check the service
@@ -94,7 +86,7 @@ service-wait-sleep () {
 # Execution
 # =========
 
-/sbin/service "$SERVICE" "$COMMAND"
+/bin/systemctl "$COMMAND" "$SERVICE"
 SERVICE_RETVAL=$?
 
 reset-defaults () {


### PR DESCRIPTION
This should fix an issue where every service was marked stopped. This caused puppet to think many services needed to start. This in turn caused other refreshes.